### PR TITLE
More specific repository URL

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "version": "0.0.5",
   "manifest_version": 2,
   "description": "Renders links to Drupal.org issues based on issue status.",
-  "homepage_url": "https://github.com/grasmash/drupal-issue-chrome",
+  "homepage_url": "https://github.com/grasmash/drupal-issue-chrome/blob/master/README.md#readme",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",


### PR DESCRIPTION
It's okay to use the code repository's front page as the link of the Support link of the extension. Seen at many others as well, so it's a common best practice.

However, this link could maybe "jump" directly down to where the README text file starts, so anyone seeking support and clicking this link doesn't need to face the entire GitHub design, only the content which matters.